### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/AbstractPoolTest.php
+++ b/tests/AbstractPoolTest.php
@@ -18,13 +18,13 @@ abstract class AbstractPoolTest extends TestCase
     abstract protected function getPool(): CacheInterface;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->pool = $this->getPool();
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->pool->clear();
     }

--- a/tests/CacheCallsTraitTest.php
+++ b/tests/CacheCallsTraitTest.php
@@ -12,7 +12,7 @@ class CacheCallsTraitTest extends TestCase
     /** @var CacheCalls */
     private $instance;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->instance = new CacheCalls();
     }

--- a/tests/CacheKeysTraitTest.php
+++ b/tests/CacheKeysTraitTest.php
@@ -12,7 +12,7 @@ class CacheKeysTraitTest extends TestCase
     /** @var CacheKeys */
     private $cache;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->cache = new CacheKeys();
     }

--- a/tests/FilesystemPoolTest.php
+++ b/tests/FilesystemPoolTest.php
@@ -19,7 +19,7 @@ class FilesystemPoolTest extends AbstractPoolTest
     private $path;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parent = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . "duncan3dc-cache-phpunit";
         $this->path = $this->parent . \DIRECTORY_SEPARATOR . "sub-directory";
@@ -27,7 +27,7 @@ class FilesystemPoolTest extends AbstractPoolTest
         parent::setUp();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected setUp` and `protected tearDown` methods.